### PR TITLE
Expose gNMI subscription settings

### DIFF
--- a/gateway/cache/cache.go
+++ b/gateway/cache/cache.go
@@ -1,0 +1,682 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cache is a tree-based cache of timestamped state provided from
+// one or more gNMI targets. It accepts updates from the target(s) to
+// refresh internal values that are made available to clients via subscriptions.
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	log "github.com/golang/glog"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	"github.com/openconfig/gnmi/ctree"
+	"github.com/openconfig/gnmi/errlist"
+	"github.com/openconfig/gnmi/latency"
+	"github.com/openconfig/gnmi/metadata"
+	"github.com/openconfig/gnmi/path"
+	"github.com/openconfig/gnmi/value"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+// T provides a shorthand function to reference a timestamp with an
+// int64 (nanoseconds since epoch).
+func T(n int64) time.Time { return time.Unix(0, n) }
+
+// A Target hosts an indexed cache of state for a single target.
+type Target struct {
+	name   string             // name of the target
+	t      *ctree.Tree        // actual cache of target data
+	client func(*ctree.Leaf)  // Function to pass all cache updates to.
+	sync   bool               // denotes whether this cache is in sync with target
+	meta   *metadata.Metadata // metadata associated with target
+	lat    *latency.Latency   // latency measurements
+	tsmu   sync.Mutex         // protects latest timestamp
+	ts     time.Time          // latest timestamp for an update
+}
+
+// Name returns the name of the target.
+func (t *Target) Name() string {
+	return t.name
+}
+
+// options contains options for creating a Cache.
+type options struct {
+	// latencyWindows is a list of time windows for which latency stats will be
+	// calculated and exported as metadata.
+	latencyWindows      []time.Duration
+	avgLatencyPrecision time.Duration
+}
+
+// Option defines the function prototype to set options for creating a Cache.
+type Option func(*options)
+
+// WithLatencyWindows returns an Option to set latency windows for which
+// latency stats are calculated and exported for each target in Cache.
+// metaUpdatePeriod is the period for updating target metadata. The latency
+// windows need to be multiples of this period.
+func WithLatencyWindows(ws []string, metaUpdatePeriod time.Duration) (Option, error) {
+	if metaUpdatePeriod.Nanoseconds() == 0 {
+		return nil, nil // disable latency stats if updatePeriod is 0
+	}
+	windows, err := latency.ParseWindows(ws, metaUpdatePeriod)
+	if err != nil {
+		return nil, err
+	}
+	return func(o *options) {
+		o.latencyWindows = windows
+	}, nil
+}
+
+// WithAvgLatencyPrecision returns an Option to set the precision of average
+// latency stats calculated in Cache.
+func WithAvgLatencyPrecision(avgLatencyPrecision time.Duration) Option {
+	return func(o *options) {
+		o.avgLatencyPrecision = avgLatencyPrecision
+	}
+}
+
+// Cache is a structure holding state information for multiple targets.
+type Cache struct {
+	opts    options
+	mu      sync.RWMutex
+	targets map[string]*Target // Map of per target caches.
+	client  func(*ctree.Leaf)  // Function to pass all cache updates to.
+}
+
+// New creates a new instance of Cache that receives target updates from the
+// translator and provides an interface to service client queries.
+func New(targets []string, opts ...Option) *Cache {
+	c := &Cache{
+		targets: make(map[string]*Target, len(targets)),
+		client:  func(*ctree.Leaf) {},
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&c.opts)
+		}
+	}
+	latency.RegisterMetadata(c.opts.latencyWindows)
+
+	for _, t := range targets {
+		c.Add(t)
+	}
+	return c
+}
+
+// LatencyWindows returns the latency windows supported by the cache.
+func (c *Cache) LatencyWindows() []time.Duration {
+	return c.opts.latencyWindows
+}
+
+// SetClient registers a callback function to receive calls for each update
+// accepted by the cache. This call should be made prior to sending any updates
+// into the cache, just after initialization.
+func (c *Cache) SetClient(client func(*ctree.Leaf)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.client = client
+	for _, t := range c.targets {
+		t.client = client
+	}
+}
+
+// Metadata returns the per-target metadata structures.
+func (c *Cache) Metadata() map[string]*metadata.Metadata {
+	md := map[string]*metadata.Metadata{}
+	defer c.mu.RUnlock()
+	c.mu.RLock()
+	for target, cache := range c.targets {
+		md[target] = cache.meta
+	}
+	return md
+}
+
+// UpdateMetadata copies the current metadata for each target cache to the
+// metadata path within each target cache.
+func (c *Cache) UpdateMetadata() {
+	c.updateCache((*Target).updateMeta)
+}
+
+// ConnectError updates the target's metadata with the provided error.
+func (c *Cache) ConnectError(name string, err error) {
+	if target := c.GetTarget(name); target != nil {
+		target.connectError(err)
+	}
+}
+
+// connectError updates the ConnectError in the cached metadata.
+func (t *Target) connectError(err error) {
+	if err := t.GnmiUpdate(metaNotiStr(t.name, metadata.ConnectError, err.Error())); err != nil {
+		log.Errorf("target %q got error during meta connect error update, %v", t.name, err)
+	}
+}
+
+// UpdateSize computes the size of each target cache and updates the size
+// metadata reported within the each target cache.
+func (c *Cache) UpdateSize() {
+	c.updateCache((*Target).updateSize)
+}
+
+// GetTarget returns the Target from the cache corresponding to the target name.
+func (c *Cache) GetTarget(target string) *Target {
+	defer c.mu.RUnlock()
+	c.mu.RLock()
+	return c.targets[target]
+}
+
+// HasTarget reports whether the specified target exists in the cache or a glob
+// (*) is passed which will match any target (even if no targets yet exist).
+func (c *Cache) HasTarget(target string) bool {
+	switch target {
+	case "":
+		return false
+	case "*":
+		return true
+	default:
+		defer c.mu.RUnlock()
+		c.mu.RLock()
+		return c.targets[target] != nil
+	}
+}
+
+// Query calls the specified callback for all results matching the query. All
+// values passed to fn are client.Notification.
+func (c *Cache) Query(target string, query []string, fn ctree.VisitFunc) error {
+	switch {
+	case target == "":
+		return errors.New("no target specified in query")
+	case target == "*":
+		defer c.mu.RUnlock()
+		c.mu.RLock()
+		// Run the query sequentially for each target cache.
+		for _, target := range c.targets {
+			if err := target.t.Query(query, fn); err != nil {
+				return err
+			}
+		}
+	default:
+		dc := c.GetTarget(target)
+		if dc == nil {
+			return fmt.Errorf("target %q not found in cache", target)
+		}
+		return dc.t.Query(query, fn)
+	}
+	return nil
+}
+
+// Add reserves space in c to receive updates for the specified target.
+func (c *Cache) Add(target string) *Target {
+	defer c.mu.Unlock()
+	c.mu.Lock()
+	var latOpts *latency.Options
+	if c.opts.avgLatencyPrecision.Nanoseconds() != 0 {
+		latOpts = &latency.Options{AvgPrecision: c.opts.avgLatencyPrecision}
+	}
+	t := &Target{
+		t:      &ctree.Tree{},
+		name:   target,
+		meta:   metadata.New(),
+		client: c.client,
+		lat:    latency.New(c.opts.latencyWindows, latOpts),
+	}
+	c.targets[target] = t
+	return t
+}
+
+// Reset clears the cache for a target once a connection is resumed after
+// having been lost.
+func (c *Cache) Reset(target string) {
+	defer c.mu.RUnlock()
+	c.mu.RLock()
+	if t := c.targets[target]; t != nil {
+		t.Reset()
+	}
+}
+
+// Remove removes the space in c corresponding to the specified target.
+func (c *Cache) Remove(target string) {
+	defer c.mu.Unlock()
+	c.mu.Lock()
+	delete(c.targets, target)
+	// Notify clients that the target is removed.
+	c.client(ctree.DetachedLeaf(deleteNoti(target, "", []string{"*"})))
+}
+
+// Sync creates an internal gnmi.Notification with metadata/sync path
+// to set the state to true for the specified target.
+func (c *Cache) Sync(name string) {
+	if target := c.GetTarget(name); target != nil {
+		target.Sync()
+	}
+}
+
+// Sync creates an internal gnmi.Notification with metadata/sync path
+// to set the state to true for the specified target.
+func (t *Target) Sync() {
+	if err := t.GnmiUpdate(metaNotiBool(t.name, metadata.Sync, true)); err != nil {
+		log.Errorf("target %q got error during meta sync update, %v", t.name, err)
+	}
+}
+
+// Connect creates an internal gnmi.Notification for metadata/connected path
+// to set the state to true for the specified target.
+func (c *Cache) Connect(name string) {
+	if target := c.GetTarget(name); target != nil {
+		target.Connect()
+	}
+}
+
+// Connect creates an internal gnmi.Notification for metadata/connected path
+// to set the state to true for the specified target, and clear connectErr.
+func (t *Target) Connect() {
+	if err := t.GnmiUpdate(metaNotiBool(t.name, metadata.Connected, true)); err != nil {
+		log.Errorf("target %q got error during meta connected update, %v", t.name, err)
+	}
+
+	if err := t.GnmiUpdate(deleteNoti(t.name, "", metadata.Path(metadata.ConnectError))); err != nil {
+		log.Errorf("target %q got error during meta connectError update, %v", t.name, err)
+	}
+}
+
+// GnmiUpdate sends a pb.Notification into the cache.
+// If the notification has multiple Updates/Deletes,
+// each individual Update/Delete is sent to cache as
+// a separate gnmi.Notification.
+func (c *Cache) GnmiUpdate(n *pb.Notification) error {
+	if n == nil {
+		return errors.New("gnmi.Notification is nil")
+	}
+	if n.GetPrefix() == nil {
+		return errors.New("gnmi.Notification prefix is nil")
+	}
+	target := c.GetTarget(n.GetPrefix().GetTarget())
+	if target == nil {
+		return fmt.Errorf("target %q not found in cache", n.GetPrefix().GetTarget())
+	}
+	return target.GnmiUpdate(n)
+}
+
+// GnmiUpdate sends a pb.Notification into the target cache.
+// If the notification has multiple Updates/Deletes,
+// each individual Update/Delete is sent to cache as
+// a separate gnmi.Notification.
+func (t *Target) GnmiUpdate(n *pb.Notification) error {
+	t.checkTimestamp(T(n.GetTimestamp()))
+	switch {
+	// Store atomic notifications as a single leaf in the tree.
+	case n.Atomic:
+		if len(n.GetDelete()) > 0 {
+			return errors.New("atomic deletes unsupported")
+		}
+		l := len(n.GetUpdate())
+		if l == 0 {
+			t.meta.AddInt(metadata.EmptyCount, 1)
+			return nil
+		}
+		nd, err := t.gnmiUpdate(n)
+		if err != nil {
+			return err
+		}
+		if nd != nil {
+			t.meta.AddInt(metadata.UpdateCount, int64(l))
+			t.client(nd)
+		}
+
+		// Break non-atomic complex notifications into individual leaves per update.
+	case len(n.GetUpdate())+len(n.GetDelete()) > 1:
+		updates := n.GetUpdate()
+		deletes := n.GetDelete()
+		n.Update, n.Delete = nil, nil
+		// restore back the notification updates and deletes
+		defer func() {
+			n.Update = updates
+			n.Delete = deletes
+		}()
+		errs := &errlist.List{}
+		for _, u := range updates {
+			noti := proto.Clone(n).(*pb.Notification)
+			noti.Update = []*pb.Update{u}
+			nd, err := t.gnmiUpdate(noti)
+			if err != nil {
+				errs.Add(err)
+				continue
+			}
+			if nd != nil {
+				t.meta.AddInt(metadata.UpdateCount, 1)
+				t.client(nd)
+			}
+		}
+
+		for _, d := range deletes {
+			noti := proto.Clone(n).(*pb.Notification)
+			noti.Delete = []*pb.Path{d}
+			t.meta.AddInt(metadata.UpdateCount, 1)
+			for _, nd := range t.gnmiRemove(noti) {
+				t.client(nd)
+			}
+		}
+		return errs.Err()
+
+	// Single update notification could be handled by the above code but is
+	// handled separately to avoid the unnecessary proto.Clone call.
+	case len(n.GetUpdate()) == 1:
+		nd, err := t.gnmiUpdate(n)
+		if err != nil {
+			return err
+		}
+		if nd != nil {
+			t.meta.AddInt(metadata.UpdateCount, 1)
+			t.client(nd)
+		}
+
+	// Single delete notification also avoids proto.Clone above.
+	case len(n.GetDelete()) == 1:
+		t.meta.AddInt(metadata.UpdateCount, 1)
+		for _, nd := range t.gnmiRemove(n) {
+			t.client(nd)
+		}
+
+	// Empty notification.
+	default:
+		t.meta.AddInt(metadata.EmptyCount, 1)
+	}
+	return nil
+}
+
+func (t *Target) checkTimestamp(ts time.Time) {
+	// Locking ensures that d.ts is always increasing regardless of the order in
+	// which updates are processed in parallel by multiple goroutines.
+	defer t.tsmu.Unlock()
+	t.tsmu.Lock()
+	// Track latest timestamp for a target.
+	if ts.After(t.ts) {
+		t.ts = ts
+	}
+}
+
+func (t *Target) gnmiUpdate(n *pb.Notification) (*ctree.Leaf, error) {
+	realData := true
+	suffix := n.Update[0].Path
+	// If the notification is an atomic group of updates, store them under the prefix only.
+	if n.Atomic {
+		suffix = nil
+	}
+	path := joinPrefixAndPath(n.Prefix, suffix)
+	if path[0] == metadata.Root {
+		realData = false
+		u := n.Update[0]
+		switch path[1] {
+		case metadata.Sync:
+			var ok bool
+			tv, ok := u.Val.Value.(*pb.TypedValue_BoolVal)
+			if !ok {
+				return nil, fmt.Errorf("%v : has value %v of type %T, expected boolean", metadata.Path(metadata.Sync), u.Val, u.Val)
+			}
+			t.sync = tv.BoolVal
+			t.meta.SetBool(metadata.Sync, t.sync)
+		case metadata.Connected:
+			tv, ok := u.Val.Value.(*pb.TypedValue_BoolVal)
+			if !ok {
+				return nil, fmt.Errorf("%v : has value %v of type %T, expected boolean", metadata.Path(metadata.Connected), u.Val, u.Val)
+			}
+			t.meta.SetBool(metadata.Connected, tv.BoolVal)
+		case metadata.ConnectedAddr, metadata.ConnectError:
+			tv, ok := u.Val.Value.(*pb.TypedValue_StringVal)
+			if !ok {
+				return nil, fmt.Errorf("%v : has value %v of type %T, expected string", metadata.Path(path[1]), u.Val, u.Val)
+			}
+			t.meta.SetStr(path[1], tv.StringVal)
+		}
+	}
+	// Update an existing leaf.
+	if oldval := t.t.GetLeaf(path); oldval != nil {
+		// An update with corrupt data is possible to visit a node that does not
+		// contain *pb.Notification. Thus, need type assertion here.
+		old, ok := oldval.Value().(*pb.Notification)
+		if !ok {
+			return nil, fmt.Errorf("corrupt schema with collision for path %q, got %T", path, oldval.Value())
+		}
+		switch {
+		case n.GetTimestamp() < old.GetTimestamp():
+			// Update rejected. Timestamp < previous recorded timestamp.
+			t.meta.AddInt(metadata.StaleCount, 1)
+			return nil, errors.New("update is stale")
+		case n.GetTimestamp() == old.GetTimestamp():
+			if !proto.Equal(old, n) {
+				if log.V(1) {
+					log.Warningf("received different value at same timestamp\nfirst: %s\nsecond: %s", prototext.Format(old), prototext.Format(n))
+				}
+				// Allow to continue to update the cache taking the last supplied value for this timestamp.
+			} else {
+				t.meta.AddInt(metadata.StaleCount, 1)
+				return nil, errors.New("update is stale")
+			}
+		}
+		oldval.Update(n)
+		// Simulate event-driven for all non-atomic updates.
+		if !n.Atomic && value.Equal(old.Update[0].Val, n.Update[0].Val) {
+			t.meta.AddInt(metadata.SuppressedCount, 1)
+			return nil, nil
+		}
+		// Compute latency for updated leaves.
+		if t.sync && realData {
+			// Record latency for post-sync target updates.  Exclude metadata updates.
+			t.lat.Compute(T(n.GetTimestamp()))
+		}
+		return oldval, nil
+	}
+	// Add a new leaf.
+	if err := t.t.Add(path, n); err != nil {
+		return nil, err
+	}
+	if realData {
+		t.meta.AddInt(metadata.LeafCount, 1)
+		t.meta.AddInt(metadata.AddCount, 1)
+		// Compute latency for new leaves.
+		if t.sync {
+			// Record latency for post-sync target updates.  Exclude metadata updates.
+			t.lat.Compute(T(n.GetTimestamp()))
+		}
+	}
+	return t.t.GetLeaf(path), nil
+}
+
+func (t *Target) gnmiRemove(n *pb.Notification) []*ctree.Leaf {
+	path := joinPrefixAndPath(n.Prefix, n.Delete[0])
+	if path[0] == metadata.Root {
+		t.meta.ResetEntry(path[1])
+	}
+	leaves := t.t.DeleteConditional(path, func(v interface{}) bool { return v.(*pb.Notification).GetTimestamp() < n.GetTimestamp() })
+	if len(leaves) == 0 {
+		return nil
+	}
+	deleted := int64(len(leaves))
+	t.meta.AddInt(metadata.LeafCount, -deleted)
+	t.meta.AddInt(metadata.DelCount, deleted)
+	var ls []*ctree.Leaf
+	for _, l := range leaves {
+		noti := &pb.Notification{
+			Timestamp: n.GetTimestamp(),
+			Prefix:    &pb.Path{Target: n.GetPrefix().GetTarget()},
+			Delete:    []*pb.Path{{Element: l}},
+		}
+		ls = append(ls, ctree.DetachedLeaf(noti))
+	}
+	return ls
+}
+
+// updateCache calls fn for each Target.
+func (c *Cache) updateCache(fn func(*Target, func(*ctree.Leaf))) {
+	defer c.mu.RUnlock()
+	c.mu.RLock()
+	for _, target := range c.targets {
+		fn(target, c.client)
+	}
+}
+
+// updateSize walks the entire tree of the target, sums up marshaled sizes of
+// all leaves and writes the sum in metadata.
+func (t *Target) updateSize(func(*ctree.Leaf)) {
+	var s int64
+	size := func(n interface{}) int64 {
+		buf, err := json.Marshal(n)
+		if err != nil {
+			return 0
+		}
+		return int64(len(buf))
+	}
+	t.t.Query([]string{"*"},
+		func(_ []string, _ *ctree.Leaf, v interface{}) error {
+			s += size(v)
+			return nil
+		})
+	t.meta.SetInt(metadata.Size, s)
+}
+
+// updateMeta updates the metadata values in the cache.
+func (t *Target) updateMeta(clients func(*ctree.Leaf)) {
+	t.tsmu.Lock()
+	latest := t.ts
+	t.tsmu.Unlock()
+	t.meta.SetInt(metadata.LatestTimestamp, latest.UnixNano())
+
+	t.lat.UpdateReset(t.meta)
+	for value := range metadata.TargetBoolValues {
+		v, err := t.meta.GetBool(value)
+		if err != nil {
+			continue
+		}
+		path := metadata.Path(value)
+		prev := t.t.GetLeafValue(path)
+		if prev == nil || prev.(*pb.Notification).Update[0].Val.Value.(*pb.TypedValue_BoolVal).BoolVal != v {
+			noti := metaNotiBool(t.name, value, v)
+			if n, _ := t.gnmiUpdate(noti); n != nil {
+				if clients != nil {
+					clients(n)
+				}
+			}
+		}
+	}
+
+	for value := range metadata.TargetIntValues {
+		v, err := t.meta.GetInt(value)
+		if err != nil {
+			continue
+		}
+		path := metadata.Path(value)
+		prev := t.t.GetLeafValue(path)
+		if prev == nil || prev.(*pb.Notification).Update[0].Val.Value.(*pb.TypedValue_IntVal).IntVal != v {
+			noti := metaNotiInt(t.name, value, v)
+			if n, _ := t.gnmiUpdate(noti); n != nil {
+				if clients != nil {
+					clients(n)
+				}
+			}
+		}
+	}
+
+	for value := range metadata.TargetStrValues {
+		v, err := t.meta.GetStr(value)
+		if err != nil {
+			continue
+		}
+		path := metadata.Path(value)
+		prev := t.t.GetLeafValue(path)
+		if prev == nil || prev.(*pb.Notification).Update[0].Val.Value.(*pb.TypedValue_StringVal).StringVal != v {
+			noti := metaNotiStr(t.name, value, v)
+			if n, _ := t.gnmiUpdate(noti); n != nil {
+				if clients != nil {
+					clients(n)
+				}
+			}
+		}
+	}
+}
+
+// Reset clears the Target of stale data upon a reconnection and notifies
+// cache client of the removal.
+func (t *Target) Reset() {
+	// Reset metadata to zero values (e.g. connected = false) and notify clients.
+	t.meta.Clear()
+	t.updateMeta(t.client)
+	for root := range t.t.Children() {
+		if root == metadata.Root {
+			continue
+		}
+		t.t.Delete([]string{root})
+		t.client(ctree.DetachedLeaf(deleteNoti(t.name, root, []string{"*"})))
+	}
+}
+
+func joinPrefixAndPath(pr, ph *pb.Path) []string {
+	// <target> and <origin> are only valid as prefix gnmi.Path
+	// https://github.com/openconfig/reference/blob/master/rpc/gnmi-specification.md#222-paths
+	p := path.ToStrings(pr, true)
+	p = append(p, path.ToStrings(ph, false)...)
+	// remove the prepended target name
+	p = p[1:]
+	return p
+}
+
+func deleteNoti(t, o string, p []string) *pb.Notification {
+	pe := make([]*pb.PathElem, 0, len(p))
+	for _, e := range p {
+		pe = append(pe, &pb.PathElem{Name: e})
+	}
+	return &pb.Notification{
+		Timestamp: time.Now().UnixNano(),
+		Prefix:    &pb.Path{Target: t, Origin: o},
+		Delete:    []*pb.Path{&pb.Path{Elem: pe}},
+	}
+}
+
+func metaNoti(t, m string, v *pb.TypedValue) *pb.Notification {
+	mp := metadata.Path(m)
+	pe := make([]*pb.PathElem, 0, len(mp))
+	for _, p := range mp {
+		pe = append(pe, &pb.PathElem{Name: p})
+	}
+	return &pb.Notification{
+		Timestamp: time.Now().UnixNano(),
+		Prefix:    &pb.Path{Target: t},
+		Update: []*pb.Update{
+			&pb.Update{
+				Path: &pb.Path{Elem: pe},
+				Val:  v,
+			},
+		},
+	}
+}
+
+func metaNotiBool(t, m string, v bool) *pb.Notification {
+	return metaNoti(t, m, &pb.TypedValue{Value: &pb.TypedValue_BoolVal{v}})
+}
+
+func metaNotiInt(t, m string, v int64) *pb.Notification {
+	return metaNoti(t, m, &pb.TypedValue{Value: &pb.TypedValue_IntVal{v}})
+}
+
+func metaNotiStr(t, m string, v string) *pb.Notification {
+	return metaNoti(t, m, &pb.TypedValue{Value: &pb.TypedValue_StringVal{v}})
+}

--- a/gateway/configuration/config.go
+++ b/gateway/configuration/config.go
@@ -45,6 +45,10 @@ type GatewayConfig struct {
 	EnableGNMIServer bool `json:"enable_gnmi_server"`
 	// Exporters contains the configuration for the included exporters.
 	Exporters *ExportersConfig `json:"exporters"`
+	// By default, the gnmi cache suppresses the notifications if there aren't
+	// any changes. However, gnmi-gw can be configured to use sampled subscribe
+	// notifications. If this flag is enabled, such notifications will be emitted.
+	EmitStaleUpdates bool `json:"emit_stale_updates"`
 	// GatewayTransitionBufferSize tunes the size of the buffer between targets and exporters/clients.
 	GatewayTransitionBufferSize uint64 `json:"gateway_transition_buffer_size"`
 	// Log is the logger used by the gateway code and gateway packages.

--- a/gateway/connections/manager.go
+++ b/gateway/connections/manager.go
@@ -36,7 +36,7 @@
 package connections
 
 import (
-	"github.com/openconfig/gnmi/cache"
+	"github.com/openconfig/gnmi-gateway/gateway/cache"
 	targetpb "github.com/openconfig/gnmi/proto/target"
 )
 

--- a/gateway/connections/state.go
+++ b/gateway/connections/state.go
@@ -347,6 +347,7 @@ func (t *ConnectionState) handleUpdate(msg proto.Message) error {
 			if targetCache == nil {
 				targetCache = t.connManager.Cache().Add(v.Update.Prefix.Target)
 			}
+			targetCache.SetEmitStaleUpdates(t.config.EmitStaleUpdates)
 			t.seenMutex.Lock()
 			t.seen[v.Update.Prefix.Target] = true
 			t.seenMutex.Unlock()
@@ -363,6 +364,7 @@ func (t *ConnectionState) handleUpdate(msg proto.Message) error {
 			if v.Update.Prefix.Target == "" {
 				v.Update.Prefix.Target = t.queryTarget
 			}
+			t.targetCache.SetEmitStaleUpdates(t.config.EmitStaleUpdates)
 			err := t.updateTargetCache(t.targetCache, v.Update)
 			if err != nil {
 				return err

--- a/gateway/connections/state.go
+++ b/gateway/connections/state.go
@@ -41,7 +41,7 @@ import (
 	"github.com/Netflix/spectator-go"
 	"github.com/Netflix/spectator-go/histogram"
 	"github.com/golang/protobuf/proto"
-	"github.com/openconfig/gnmi/cache"
+	"github.com/openconfig/gnmi-gateway/gateway/cache"
 	"github.com/openconfig/gnmi/client"
 	gnmiclient "github.com/openconfig/gnmi/client/gnmi"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"

--- a/gateway/connections/state_test.go
+++ b/gateway/connections/state_test.go
@@ -16,7 +16,7 @@
 package connections
 
 import (
-	"github.com/openconfig/gnmi/cache"
+	"github.com/openconfig/gnmi-gateway/gateway/cache"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/gateway/connections/zookeeper.go
+++ b/gateway/connections/zookeeper.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/go-zookeeper/zk"
-	"github.com/openconfig/gnmi/cache"
+	"github.com/openconfig/gnmi-gateway/gateway/cache"
 	targetpb "github.com/openconfig/gnmi/proto/target"
 	targetlib "github.com/openconfig/gnmi/target"
 	"github.com/rs/zerolog/log"

--- a/gateway/exporters/exporter_mock_test.go
+++ b/gateway/exporters/exporter_mock_test.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	cache "github.com/openconfig/gnmi/cache"
+	cache "github.com/openconfig/gnmi-gateway/gateway/cache"
 	ctree "github.com/openconfig/gnmi/ctree"
 )
 

--- a/gateway/exporters/influxdb/influxdb.go
+++ b/gateway/exporters/influxdb/influxdb.go
@@ -24,7 +24,7 @@ import (
 	"github.com/openconfig/gnmi-gateway/gateway/connections"
 	"github.com/openconfig/gnmi-gateway/gateway/exporters"
 	"github.com/openconfig/gnmi-gateway/gateway/utils"
-	"github.com/openconfig/gnmi/cache"
+	"github.com/openconfig/gnmi-gateway/gateway/cache"
 	"github.com/openconfig/gnmi/ctree"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 )

--- a/gateway/exporters/kafka/kafka.go
+++ b/gateway/exporters/kafka/kafka.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/openconfig/gnmi/cache"
+	"github.com/openconfig/gnmi-gateway/gateway/cache"
 	"github.com/openconfig/gnmi/ctree"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/rs/zerolog"

--- a/gateway/loaders/zookeeper/zookeeper.go
+++ b/gateway/loaders/zookeeper/zookeeper.go
@@ -54,6 +54,12 @@ type RequestConfig struct {
 	// suppress_redundant is in use. The target should send a value at least once
 	// in the period specified.
 	HeartbeatInterval uint64 `yaml:"heartbeatInterval"`
+	// An optional field to specify that only updates to current state should be
+	// sent to a client. If set, the initial state is not sent to the client but
+	// rather only the sync message followed by any subsequent updates to the
+	// current state. For ONCE and POLL modes, this causes the server to send only
+	// the sync message (Sec. 3.5.2.3).
+	UpdatesOnly bool `yaml:"updatesOnly"`
 
 }
 
@@ -306,6 +312,7 @@ func (z *ZookeeperTargetLoader) zookeeperToTargets(t *TargetConfig) (*targetpb.C
 						Target: request.Target,
 					},
 					Subscription: subs,
+					UpdatesOnly: request.UpdatesOnly,
 				},
 			},
 		}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -93,6 +93,7 @@ func ParseArgs(config *configuration.GatewayConfig) error {
 	// Configuration Parameters
 	configFile := flag.String("ConfigFile", "", "Path of the gateway configuration JSON file.")
 	flag.BoolVar(&config.EnableGNMIServer, "EnableGNMIServer", false, "Enable the gNMI server")
+	flag.BoolVar(&config.EmitStaleUpdates, "EmitStaleUpdates", true, "Emit stale updates")
 	exporters := flag.String("Exporters", "", "Comma-separated list of Exporters to enable.")
 	flag.Int64Var(&config.Exporters.KafkaBatchBytes, "ExporterKafkaBatchBytes", 1048576, "Max bytes that will be buffered before flushing messages to a Kafka partition")
 	flag.IntVar(&config.Exporters.KafkaBatchSize, "ExporterKafkaBatchSize", 10000, "Max number of messages that will be buffered before flushing messages to a Kafka partition")

--- a/gateway/server/server.go
+++ b/gateway/server/server.go
@@ -50,7 +50,7 @@ import (
 	"github.com/openconfig/gnmi-gateway/gateway/stats"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/openconfig/gnmi/cache"
+	"github.com/openconfig/gnmi-gateway/gateway/cache"
 	"github.com/openconfig/gnmi/coalesce"
 	"github.com/openconfig/gnmi/ctree"
 	"github.com/openconfig/gnmi/match"

--- a/gateway/server/server_test.go
+++ b/gateway/server/server_test.go
@@ -53,7 +53,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/openconfig/gnmi/cache"
+	"github.com/openconfig/gnmi-gateway/gateway/cache"
 	"github.com/openconfig/gnmi/client"
 	gnmiclient "github.com/openconfig/gnmi/client/gnmi"
 	"github.com/openconfig/gnmi/ctree"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.2.3
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/netbox-community/go-netbox v0.0.0-20201002085217-91e5d561efe4
-	github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802
+	github.com/openconfig/gnmi v0.0.0-20220503232738-6eb133c65a13
 	github.com/openconfig/goyang v0.0.0-20200623182805-6be32aef2bcd
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rs/zerolog v1.17.2
@@ -30,7 +30,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cenkalti/backoff/v4 v4.0.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.3.13 // indirect
 	github.com/frankban/quicktest v1.11.1 // indirect
@@ -57,6 +57,7 @@ require (
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d // indirect
 	github.com/openconfig/ygot v0.8.0 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -69,7 +70,7 @@ require (
 	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 // indirect
+	google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=
 github.com/cenkalti/backoff/v4 v4.0.0 h1:6VeaLF9aI+MAUQ95106HwWzYZgJJpZ4stumjj6RFYAU=
 github.com/cenkalti/backoff/v4 v4.0.0/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -78,6 +80,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -110,6 +113,7 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
@@ -453,10 +457,14 @@ github.com/openconfig/gnmi v0.0.0-20200414194230-1597cc0f2600/go.mod h1:M/EcuapN
 github.com/openconfig/gnmi v0.0.0-20200508230933-d19cebf5e7be/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
 github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802 h1:WXFwJlWOJINlwlyAZuNo4GdYZS6qPX36+rRUncLmN8Q=
 github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
+github.com/openconfig/gnmi v0.0.0-20220503232738-6eb133c65a13 h1:6MHJ6YxMDr/dhS4mnM3sZxmolqgJw36ibOtwXNHTo6M=
+github.com/openconfig/gnmi v0.0.0-20220503232738-6eb133c65a13/go.mod h1:h365Ifq35G6kLZDQlRvrccTt2LKK90VpjZLMNGxJRYc=
 github.com/openconfig/goyang v0.0.0-20200115183954-d0a48929f0ea/go.mod h1:dhXaV0JgHJzdrHi2l+w0fZrwArtXL7jEFoiqLEdmkvU=
 github.com/openconfig/goyang v0.0.0-20200603222342-a0c8aa1ee274/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+RrNkXRd3W8=
 github.com/openconfig/goyang v0.0.0-20200623182805-6be32aef2bcd h1:hY5WHBFKH+yl3P1CdxtuhDuffncqfJLpQM+b1LwsK9k=
 github.com/openconfig/goyang v0.0.0-20200623182805-6be32aef2bcd/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+RrNkXRd3W8=
+github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d h1:zrs4U92QEAadFotQyidT4U8iZDJO67pXsS4r64uAHik=
+github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d/go.mod h1:x9tAZ4EwqCQ0jI8D6S8Yhw9Z0ee7/BxWQX0k0Uib5Q8=
 github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=
 github.com/openconfig/ygot v0.8.0 h1:b4aE8fFTE+b+DgUatCNeJmp22Vaom5Wk7slCnQ5+bbI=
 github.com/openconfig/ygot v0.8.0/go.mod h1:p9HLFh47WYWnuxDSpZoQrH7UTQHlw5mH+Z4OSCigzZU=
@@ -676,6 +684,7 @@ golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a h1:bRuuGXV8wwSdGTB+CtJf+FjgO1APK1CoO39T4BN/XBw=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -746,6 +755,7 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -757,6 +767,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
@@ -877,6 +888,8 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 h1:PDIOdWxZ8eRizhKa1AAvY53xsvLB1cWorMjslvY3VA8=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d h1:HV9Z9qMhQEsdlvxNFELgQ11RkMzO3CMkjEySjCtuLes=
+google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.2.1-0.20170921194603-d4b75ebd4f9f/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -892,9 +905,11 @@ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3Iji
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
+google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.40.0 h1:AGJ0Ih4mHjSeibYkFGh1dD9KJ/eOtZ93I6hoHhukQ5Q=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
Expose gNMI subscription settings

gnmi-gateway uses the "on-change" subscription mode. However, we'll need to retrieve certain metrics periodically.

For that, we'll expose additional gNMI subscription parameters as part of the request configuration:
* mode (0 - target defined, 1 - on change, 2 - sampled)
* sample interval (ns)
* supress redundant (bool)
* heartbeat interval - if "supress redundant" is enabled, defines
  at least one notification per heartbeat interval will be issued,
  even if there hasn't been any change.
* update only - if set, the initial state will be omitted

Note that by default, the gnmi cache is dropping notifications if there aren't any changes compared to the previously received update.  We'll make this configurable through the "EmitStaleUpdates" setting and CLI parameter.

In order to change the gnmi cache behavior, we'll need to vendorize it. Alternatives:

* vendorize the entire gnmi library - not necessary, more difficult to maintain
* bypass the cache when hitting stale update errors or completely disable the cache - might have unforeseen consequences