### PR TITLE
Improve request target wildcards

### DIFF
--- a/gateway/connections/zookeeper.go
+++ b/gateway/connections/zookeeper.go
@@ -16,6 +16,7 @@
 package connections
 
 import (
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -99,6 +100,10 @@ func (c *ZookeeperConnectionManager) Forwardable(target string) bool {
 		}
 
 		if conn.queryTarget == target || conn.Seen(target) {
+			return true
+		}
+
+		if match, _ := filepath.Match(target, conn.queryTarget); match {
 			return true
 		}
 	}

--- a/gateway/loaders/zookeeper/utils.go
+++ b/gateway/loaders/zookeeper/utils.go
@@ -193,9 +193,6 @@ func ValidateConnection(c *ConnectionConfig) error {
 	if len(c.Addresses) == 0 {
 		return fmt.Errorf("target missing address")
 	}
-	if c.Request == "" {
-		return fmt.Errorf("target missing request")
-	}
 
 	return nil
 }

--- a/gateway/utils/utils.go
+++ b/gateway/utils/utils.go
@@ -135,3 +135,7 @@ func GetNumberValues(tv *gnmi.TypedValue) (float64, bool) {
 	}
 	return 0, false
 }
+
+func IsWildcardTarget(target string) bool {
+	return strings.Contains(target, "*")
+}


### PR DESCRIPTION
Improve request target wildcards

Right now, each target is supposed to have an associated request,
while the requests have either a backreference to a target or
a "*" target (default requests).

We need a more flexible way of defining gnmi requests, so we're
making the following changes:

* targets no longer have to explicitly reference a request
* the requests can reference multiple targets by using glob patterns
  such as ce*, tor*, etc.

Since the gnmi library still requires one request per target, we're
going to aggregate the requests that gnmi-gw receives.

For now, we're only covering the zookeeper target loader.