### PR TITLE
Avoid misleading log message

### DIFF
--- a/gateway/loaders/zookeeper/zookeeper.go
+++ b/gateway/loaders/zookeeper/zookeeper.go
@@ -385,12 +385,3 @@ func (z *ZookeeperTargetLoader) zookeeperToTargets(t *TargetConfig) (*targetpb.C
 
 	return configs, nil
 }
-
-func getRequestTargetName(targets map[string]*targetpb.Target, requestName string) (string, bool) {
-	for target, config := range targets {
-		if config.Request == requestName {
-			return target, true
-		}
-	}
-	return "", false
-}

--- a/gateway/loaders/zookeeper/zookeeper.go
+++ b/gateway/loaders/zookeeper/zookeeper.go
@@ -346,7 +346,8 @@ func (z *ZookeeperTargetLoader) zookeeperToTargets(t *TargetConfig) (*targetpb.C
 				// requests by merging "ce_metrics" and "ce_events", one for
 				// each of the "ce1" and "ce2" targets.
 				var targetRequest *gnmi.SubscribeRequest
-				if targetRequest, found = configs.Request[targetName]; !found {
+				var foundSub bool
+				if targetRequest, foundSub = configs.Request[targetName]; !foundSub {
 					targetRequest = &gnmi.SubscribeRequest{
 						Request: &gnmi.SubscribeRequest_Subscribe{
 							Subscribe: &gnmi.SubscriptionList{


### PR DESCRIPTION
We're logging "No matching target for request" despite actually
finding a target match. The reason is that the "found" variable
is reused by the same code block but for a different purpose.

We'll fix this issue by adding another variable called "foundSub",
which is going to be used when searching for existing subscriptions.

While at it, we'll remove a method that's no longer used.