### PR TITLE
Avoid deadlock when reconnecting

### DIFF
--- a/gateway/connections/state.go
+++ b/gateway/connections/state.go
@@ -300,13 +300,7 @@ func (t *ConnectionState) disconnected() {
 
 func (t *ConnectionState) reconnect(connectionSlot *semaphore.Weighted) error {
 	t.config.Log.Info().Msgf("Target %s: Reconnecting", t.name)
-	// if t.connecting
-	if err := t.client.Close(); err != nil {
-		return err
-	}
-
-	go t.connect(connectionSlot)
-	return nil
+	return t.client.Close()
 }
 
 func (t *ConnectionState) unlock() error {

--- a/gateway/connections/zookeeper.go
+++ b/gateway/connections/zookeeper.go
@@ -136,10 +136,7 @@ func (c *ZookeeperConnectionManager) handleTargetControlMsg(msg *TargetConnectio
 	for _, toRemove := range msg.Remove {
 		conn, exists := c.connections[toRemove]
 		if exists {
-			err := conn.disconnect()
-			if err != nil {
-				c.config.Log.Warn().Msgf("error while disconnecting from target '%s': %v", toRemove, err)
-			}
+			go conn.disconnect()
 			delete(c.connections, toRemove)
 		}
 	}
@@ -189,60 +186,9 @@ func (c *ZookeeperConnectionManager) handleTargetControlMsg(msg *TargetConnectio
 	}
 
 	if msg.ReconnectAll {
-		// targets := make(map[string]*targetpb.Target)
-		// targetNames := []string{}
 		for _, conn := range c.connections {
-			// c.config.Log.Info().Msgf("Reconnecting conn: ", conn)
-			if err := conn.reconnect(c.connLimit); err != nil {
-				c.config.Log.Error().Msgf("Reconnect failed: ", err)
-			}
-
-			// targetNames = append(targetNames, conn.name)
-
-			// Idea 1
-			// targets[conn.name] = conn.target
-
-			// Idea 2
-			// delete(c.connections, connName)
-
-			// _, noLock := conn.target.Meta["NoLock"]
-			// c.config.Log.Info().Msgf("Initializing target %s (%v) %v. ; using lock: %v", conn.name, conn.target.Addresses, conn.target.Meta, c.zkConn != nil && !noLock)
-
-			// c.connections[connName].InitializeMetrics()
-			// if c.connections[connName].useLock {
-			// 	lockPath := MakeTargetLockPath(c.config.ZookeeperPrefix, connName)
-			// 	clusterMemberAddress := c.config.ServerAddress + ":" + strconv.Itoa(c.config.ServerPort)
-			// 	c.connections[connName].lock = locking.NewZookeeperNonBlockingLock(c.zkConn, lockPath, clusterMemberAddress, zk.WorldACL(zk.PermAll))
-			// 	go c.connections[connName].connectWithLock(c.connLimit)
-			// } else {
-			// 	go c.connections[connName].connect(c.connLimit)
-			// }
-
-			// Idea 3
-			// connecting := conn.connecting
-			// c.config.Log.Info().Msgf("connecting init: ", connecting)
-
-			// conn.disconnect()
-			// c.config.Log.Info().Msgf("connecting after disconnect: ", connecting)
-
-			// conn.disconnected()
-			// c.config.Log.Info().Msgf("connecting after disconnected: ", connecting)
-
-			// conn.reset()
-			// c.config.Log.Info().Msgf("connecting after reset: ", connecting)
-
-			// conn.doConnect()
-			// c.config.Log.Info().Msgf("connecting after doConnect: ", connecting)
-			// c.config.Log.Info().Msgf("connected: ", conn.connected)
+			go conn.reconnect(c.connLimit)
 		}
-
-		// controlMsg := new(TargetConnectionControl)
-		// controlMsg.ReconnectAll = false
-		// controlMsg.Insert = &targetpb.Configuration{
-		// 	Target: targets,
-		// }
-		// controlMsg.Remove = targetNames
-		// c.handleTargetControlMsg(controlMsg)
 	}
 
 	c.connectionsMutex.Unlock()


### PR DESCRIPTION
The gnmi cache gets reset when removing or recreating connections.
Any cached notification will be pushed to the exporters.

The issue is that ZookeeperConnectionManager.Forwardable loops
over the connections, tries to acquire the connection lock and
enters a deadlock.

A simple workaround would be to just invoke the disconnect/reconnect
calls asynchronously. Worth mentioning that "connect" call is already
async.

At the same time, we can restore the old reconnect implementation,
which is simply closing the underlying connection, which in turn will
trigger a reconnect attempt.