### PR TITLE
Allow associating metadata with gnmi paths

### DIFF
--- a/gateway/configuration/config_test.go
+++ b/gateway/configuration/config_test.go
@@ -1,0 +1,55 @@
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_pathMetadata(t *testing.T) {
+	assertion := assert.New(t)
+
+	cfg := NewDefaultGatewayConfig()
+
+	cfg.AddPathMetadata("/test/a", map[string]string{
+		"a": "childA",
+		"b": "childB",
+	})
+	cfg.AddPathMetadata("/test", map[string]string{
+		"a": "parentA",
+		"c": "parentC",
+	})
+	cfg.AddPathMetadata("/", map[string]string{
+		"d": "root",
+	})
+
+	assertion.Equal(
+		map[string]string{
+			"a": "childA",
+			"b": "childB",
+			"c": "parentC",
+			"d": "root",
+		},
+		cfg.GetPathMetadata("/test/a"),
+	)
+	assertion.Equal(
+		map[string]string{
+			"a": "parentA",
+			"c": "parentC",
+			"d": "root",
+		},
+		cfg.GetPathMetadata("/test"),
+	)
+	assertion.Equal(
+		map[string]string{
+			"d": "root",
+		},
+		cfg.GetPathMetadata("/"),
+	)
+	assertion.Equal(
+		map[string]string{
+			"d": "root",
+		},
+		cfg.GetPathMetadata("/some/other/path"),
+	)
+}

--- a/gateway/exporters/debug/debug.go
+++ b/gateway/exporters/debug/debug.go
@@ -18,6 +18,8 @@
 package debug
 
 import (
+	"fmt"
+
 	"github.com/openconfig/gnmi/ctree"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 
@@ -53,7 +55,19 @@ func (e *DebugExporter) Name() string {
 
 func (e *DebugExporter) Export(leaf *ctree.Leaf) {
 	notification := leaf.Value().(*gnmipb.Notification)
-	e.config.Log.Info().Msg(utils.GNMINotificationPrettyString(notification))
+	msg := utils.GNMINotificationPrettyString(notification)
+
+	if len(notification.Update) > 0 {
+		msg += " update_path_meta:[ "
+		for _, u := range notification.Update {
+			msg += fmt.Sprintf(
+				"%v, ", e.config.GetPathMetadata(
+					utils.GetTrimmedPath(notification.Prefix, u.Path)))
+		}
+		msg += "] "
+	}
+
+	e.config.Log.Info().Msg(msg)
 }
 
 func (e *DebugExporter) Start(connMgr *connections.ConnectionManager) error {

--- a/gateway/utils/utils.go
+++ b/gateway/utils/utils.go
@@ -108,6 +108,27 @@ func PathToXPath(path *gnmi.Path) string {
 	return xPath
 }
 
+// Retrieve a gnmi path, trimming the following:
+//		* gnmi origin
+//		* gnmi target
+//		* key filters
+func GetTrimmedPath(prefix *gnmi.Path, path *gnmi.Path) string {
+	var xPath string
+
+	for _, elem := range prefix.Elem {
+		if elem.Name != "" {
+			xPath += "/" + elem.Name
+		}
+	}
+
+	for _, elem := range path.Elem {
+		if elem.Name != "" {
+			xPath += "/" + elem.Name
+		}
+	}
+	return xPath
+}
+
 func GetNumberValues(tv *gnmi.TypedValue) (float64, bool) {
 	if tv != nil && tv.Value != nil {
 		switch tv.Value.(type) {


### PR DESCRIPTION
Our exporters need additional information based on the gnmi path
(e.g. whether to handle the data as a metric or as an event, the
log namespace, etc).

We'll allow defining arbitrary metadata for groups of gnmi paths,
which will be stored in Zookeeper.

Child gnmi nodes inherit their parent metadata. Let's take the
following example:

	path: /a
	metadata: {"a": "parent", "b": "b"}

	path: /a/child
	metadata: {"a": "child"}

The resulting metadata for "/a/child" will be {"a": "child", "b": "b"}.