### PR TITLE
Properly handle removed path metadata

### DIFF
--- a/gateway/configuration/config.go
+++ b/gateway/configuration/config.go
@@ -293,3 +293,12 @@ func (c *GatewayConfig) AddPathMetadata(path string, meta map[string]string) {
 		(*pathMeta)[key] = val
 	}
 }
+
+func (c *GatewayConfig) ReplacePathMetadata(
+	meta map[string]*map[string]string,
+) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.pathMeta = meta
+}

--- a/gateway/loaders/zookeeper/utils.go
+++ b/gateway/loaders/zookeeper/utils.go
@@ -72,22 +72,11 @@ func (z *ZookeeperTargetLoader) refreshGlobalConfig(log zerolog.Logger, targetCh
 }
 
 func (z *ZookeeperTargetLoader) refreshPathMeta() error {
-	// TODO: right now, the path metadata is specified using
-	// /pathMeta/$groupName Zookeeper nodes *and* as part of the gnmi requests
-	// at /requests/$requestID.
-	//
-	// The issue is that a single path may receive metadata from multiple sources,
-	// which makes it difficult to perform cleanups.
-	//
-	// We should unify the above, perhaps moving request path metadata
-	// to something like /pathMeta/$requestID-meta.
 	meta, err := z.zkClient.getPathMeta(z.config.Log)
 	if err != nil {
 		return err
 	}
-	for key, val := range meta {
-		z.config.AddPathMetadata(key, *val)
-	}
+	z.config.ReplacePathMetadata(meta)
 	return nil
 }
 

--- a/gateway/loaders/zookeeper/zookeeper.go
+++ b/gateway/loaders/zookeeper/zookeeper.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openconfig/gnmi-gateway/gateway/configuration"
 	"github.com/openconfig/gnmi-gateway/gateway/connections"
 	"github.com/openconfig/gnmi-gateway/gateway/loaders"
-	"github.com/openconfig/gnmi-gateway/gateway/utils"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	targetpb "github.com/openconfig/gnmi/proto/target"
 	"github.com/openconfig/gnmi/target"
@@ -48,9 +47,6 @@ type CredentialsConfig struct {
 type RequestConfig struct {
 	Target string   `yaml:"target"`
 	Paths  []string `yaml:"paths"`
-	// metadata associated with the specified gnmi paths, used by the gnmi-gw
-	// exporters.
-	PathMeta map[string]string `yaml:"pathMeta"`
 	// Subscription mode to be used:
 	// 0: SubscriptionMode_TARGET_DEFINED - The target selects the relevant
 	// 										mode for each element.
@@ -400,12 +396,6 @@ func (z *ZookeeperTargetLoader) zookeeperToTargets(t *TargetConfig) (*targetpb.C
 				SuppressRedundant: request.SuppressRedundant,
 				HeartbeatInterval: request.HeartbeatInterval,
 			})
-
-			if len(request.PathMeta) > 0 {
-				z.config.AddPathMetadata(
-					utils.GetTrimmedPath(&gnmi.Path{}, path),
-					request.PathMeta)
-			}
 		}
 		found := false
 		for targetName := range configs.Target {


### PR DESCRIPTION
Our zookeeper loader doesn't update the cached path metadata
when metadata items are removed.

To simplify the gnmi-gw logic and fix this issue, we'll no longer
allow specifying path metadata as part of the request config.
Instead, we'll only use the /pathMeta/$groupID zk nodess.