### PR TITLE
Parallelize export calls

### DIFF
--- a/gateway/configuration/config.go
+++ b/gateway/configuration/config.go
@@ -52,6 +52,8 @@ type GatewayConfig struct {
 	// any changes. However, gnmi-gw can be configured to use sampled subscribe
 	// notifications. If this flag is enabled, such notifications will be emitted.
 	EmitStaleUpdates bool `json:"emit_stale_updates"`
+	// GatewayTransitionWorkerCount sets the number of workers that push metrics between targets and exporters/clients.
+	GatewayTransitionWorkerCount uint64 `json:"gateway_transition_worker_count"`
 	// GatewayTransitionBufferSize tunes the size of the buffer between targets and exporters/clients.
 	GatewayTransitionBufferSize uint64 `json:"gateway_transition_buffer_size"`
 	// Log is the logger used by the gateway code and gateway packages.

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -112,6 +112,7 @@ func ParseArgs(config *configuration.GatewayConfig) error {
 
 	flag.StringVar(&config.Exporters.StatsdHost, "ExportersStatsdHost", "", "Statsd exporter host including port")
 
+	flag.Uint64Var(&config.GatewayTransitionWorkerCount, "GatewayTransitionWorkerCount", 100, "Sets the number of workers that push metrics between targets and exporters/clients.")
 	flag.Uint64Var(&config.GatewayTransitionBufferSize, "GatewayTransitionBufferSize", 100000, "Tunes the size of the buffer between targets and exporters/clients")
 	flag.BoolVar(&config.LogCaller, "LogCaller", false, "Include the file and line number with each log message")
 	flag.StringVar(&config.OpenConfigDirectory, "OpenConfigDirectory", "", "Directory (required to enable Prometheus exporter)")

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.11.1
 )
 
+require github.com/alitto/pond v1.8.0 // indirect
+
 require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alitto/pond v1.8.0 h1:/4wnAU0vOjhsUxOxjtXuNb59oh0J+Jjukf6gtkWpGJk=
+github.com/alitto/pond v1.8.0/go.mod h1:xQn3P/sHTYcU/1BR3i86IGIrilcrGC2LiS+E2+CJWsI=
 github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6/go.mod h1:+lx6/Aqd1kLJ1GQfkvOnaZ1WGmLpMpbprPuIOOZX30U=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=


### PR DESCRIPTION
We expect a large number of metrics to be pushed through our
exporters, which is why we're replacing the synchronous export
queue with a goroutine pool.

We're going to leverage the "pond"[1] library, which seems very
promissing (good adoption rate, well documented, simple API and
implementation, said to be efficient).

[1] https://github.com/alitto/pond