### PR TITLE
Geneva Exporter (statsd conversion)

### DIFF
--- a/gateway/configuration/config.go
+++ b/gateway/configuration/config.go
@@ -159,6 +159,10 @@ type ExportersConfig struct {
 
 	// StatsdHost is the target address for the statsd exporter
 	StatsdHost string `json:"statsd_host"`
+	// FluentHost is the target address for the fluentd target
+	FluentHost string `json:"fluent_host"`
+	// FluentPort is the target port for the fluentd target
+	FluentPort int `json:"fluent_port"`
 }
 
 type TargetLoadersConfig struct {
@@ -209,7 +213,7 @@ func NewDefaultGatewayConfig() *GatewayConfig {
 		Exporters:     new(ExportersConfig),
 		Log:           zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.InfoLevel),
 		TargetLoaders: new(TargetLoadersConfig),
-		pathMeta: make(map[string]*map[string]string, 0),
+		pathMeta:      make(map[string]*map[string]string, 0),
 	}
 	return config
 }

--- a/gateway/configuration/config.go
+++ b/gateway/configuration/config.go
@@ -163,6 +163,10 @@ type ExportersConfig struct {
 	FluentHost string `json:"fluent_host"`
 	// FluentPort is the target port for the fluentd target
 	FluentPort int `json:"fluent_port"`
+	// GenevaMdmAccount is the corresponding MDM account for pushing metrics into Geneva
+	GenevaMdmAccount string `json:"geneva_mdm_account"`
+	// ExtensionArmId is the ARM ID of the Azure extension of which gnmi-gateway is part of (if needed)
+	ExtensionArmId string `json:"extension_arm_id"`
 }
 
 type TargetLoadersConfig struct {

--- a/gateway/exporters/statsd/statsd.go
+++ b/gateway/exporters/statsd/statsd.go
@@ -169,7 +169,7 @@ func (e *StatsdExporter) Export(leaf *ctree.Leaf) {
 
 		if e.logger != nil && (notificationType == "log" || notificationType == "metricAndLog") {
 			if err := e.logger.Post(metric.Measurement, metric); err != nil {
-				e.config.Log.Error().Msg("failed emmiting event log to fluentd")
+				e.config.Log.Error().Msg("failed emmiting event log to fluentd: " + err.Error())
 			}
 		}
 	}
@@ -192,9 +192,12 @@ func (e *StatsdExporter) Start(connMgr *connections.ConnectionManager) error {
 	}
 
 	if e.config.Exporters.FluentHost != "" {
+		// TODO: Perhaps add some exporter config parameters for config values
 		e.logger, err = fluent.New(fluent.Config{
-			FluentHost: e.config.Exporters.FluentHost,
-			FluentPort: e.config.Exporters.FluentPort,
+			FluentHost:             e.config.Exporters.FluentHost,
+			FluentPort:             e.config.Exporters.FluentPort,
+			Async:                  true,
+			AsyncReconnectInterval: 500,
 		})
 	}
 

--- a/gateway/exporters/statsd/statsd.go
+++ b/gateway/exporters/statsd/statsd.go
@@ -210,13 +210,8 @@ func extractPrefixAndPathKeys(prefix *gnmipb.Path, metricPath *gnmipb.Path) ([]s
 		for _, e := range metricPath.Elem {
 			name := e.Name
 			elems = append(elems, name)
-
 			for k, v := range e.GetKey() {
-				if _, ok := keys[k]; ok {
-					keys[name+"/"+k] = v
-				} else {
-					keys[k] = v
-				}
+				keys[e.Name+"_"+k] = v
 			}
 		}
 	}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -110,7 +110,9 @@ func ParseArgs(config *configuration.GatewayConfig) error {
 
 	exporterMetadataAllowlist := flag.String("ExportersMetadataAllowlist", "", "Comma separated (no spaces) list of metadata fields to include in notifications")
 
-	flag.StringVar(&config.Exporters.StatsdHost, "ExportersStatsdHost", "", "Statsd exporter host including port")
+	flag.StringVar(&config.Exporters.StatsdHost, "ExportersStatsdHost", "", "Geneva exporter statsd host including port")
+	flag.StringVar(&config.Exporters.FluentHost, "ExportersFluentHost", "", "Geneva exporter fluentd host address")
+	flag.IntVar(&config.Exporters.FluentPort, "ExportersFluentPort", 8130, "Geneva exporter fluentd host port")
 
 	flag.Uint64Var(&config.GatewayTransitionBufferSize, "GatewayTransitionBufferSize", 100000, "Tunes the size of the buffer between targets and exporters/clients")
 	flag.BoolVar(&config.LogCaller, "LogCaller", false, "Include the file and line number with each log message")

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -113,6 +113,8 @@ func ParseArgs(config *configuration.GatewayConfig) error {
 	flag.StringVar(&config.Exporters.StatsdHost, "ExportersStatsdHost", "", "Geneva exporter statsd host including port")
 	flag.StringVar(&config.Exporters.FluentHost, "ExportersFluentHost", "", "Geneva exporter fluentd host address")
 	flag.IntVar(&config.Exporters.FluentPort, "ExportersFluentPort", 8130, "Geneva exporter fluentd host port")
+	flag.StringVar(&config.Exporters.GenevaMdmAccount, "ExportersMdmAccount", "", "Geneva exporter MDM account")
+	flag.StringVar(&config.Exporters.ExtensionArmId, "ExportersExtensionArmId", "", "ARM ID of the Azure extension of which gnmi-gateway is part of")
 
 	flag.Uint64Var(&config.GatewayTransitionBufferSize, "GatewayTransitionBufferSize", 100000, "Tunes the size of the buffer between targets and exporters/clients")
 	flag.BoolVar(&config.LogCaller, "LogCaller", false, "Include the file and line number with each log message")

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,12 @@ require (
 )
 
 require (
+	github.com/fluent/fluent-logger-golang v1.9.0 // indirect
+	github.com/philhofer/fwd v1.1.1 // indirect
+	github.com/tinylib/msgp v1.1.6 // indirect
+)
+
+require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/etsy/statsd v0.9.0 h1:GLP1pAzn1fGE7/kM2S5QXSU0ZTUV6QnZsyZVMx7IVF4=
 github.com/etsy/statsd v0.9.0/go.mod h1:rmx2gVm1TEkQUIcU/KAM4prmC/AAUU8Wndeule9gvW4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fluent/fluent-logger-golang v1.9.0 h1:zUdY44CHX2oIUc7VTNZc+4m+ORuO/mldQDA7czhWXEg=
+github.com/fluent/fluent-logger-golang v1.9.0/go.mod h1:2/HCT/jTy78yGyeNGQLGQsjF3zzzAuy6Xlk6FCMV5eU=
 github.com/frankban/quicktest v1.11.1 h1:stwUsXhUGliQs9t0ZS39BWCltFdOHgABiIlihop8AD4=
 github.com/frankban/quicktest v1.11.1/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/fsnotify/fsnotify v1.4.3-0.20170329110642-4da3e2cfbabc/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -482,6 +484,8 @@ github.com/pelletier/go-toml v1.0.1-0.20170904195809-1d6b12b7cb29/go.mod h1:5z9K
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
+github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
+github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -572,6 +576,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=
+github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
@@ -590,6 +596,7 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
@@ -691,6 +698,7 @@ golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a h1:bRuuGXV8wwSdGTB+CtJf+FjgO1APK1CoO39T4BN/XBw=
@@ -712,6 +720,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -761,6 +770,7 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -833,6 +843,7 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Converting statsd exporter to geneva exporter.

This modified exporter will handle both metrics and event logging as follows:

-  metrics shall be sent to a Geneva mdm agent via statsd
-  events shall be sent to a Geneva mds agent via fluentd