### PR TITLE
Add exporter benchmarks and buffer statsd notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ server.key
 
 # Emitted binary and releases
 gnmi-gateway
+statsd-benchmark
+statsd-server
+
 release/
 
 # OpenConfig models download

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ build: clean
 	go build -o gnmi-gateway $(GOFLAGS) .
 	./gnmi-gateway -version
 
+benchmark:
+	go build -o statsd-benchmark $(GOFLAGS) gateway/benchmarks/exporter/main.go
+	go build -o statsd-server $(GOFLAGS) gateway/benchmarks/statsd_server/cmd/main.go
+
 clean:
 	rm -f gnmi-gateway
 	rm -f cover.out

--- a/gateway/benchmarks/exporter/main.go
+++ b/gateway/benchmarks/exporter/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/openconfig/gnmi-gateway/gateway/configuration"
+	"github.com/openconfig/gnmi/ctree"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/rs/zerolog"
+
+	"github.com/openconfig/gnmi-gateway/gateway/benchmarks/statsd_server"
+	"github.com/openconfig/gnmi-gateway/gateway/exporters/statsd"
+)
+
+const (
+	serverAddress = "127.0.0.1"
+	serverPort = 8125
+
+	expNotifications = 150000
+	// how long to wait for all the notifications to be received on the statsd
+	// side.
+	testTimeoutS = 15
+)
+
+var (
+	config = &configuration.GatewayConfig{
+		Exporters: &configuration.ExportersConfig{
+			StatsdHost: fmt.Sprintf("%s:%d", serverAddress, serverPort),
+		},
+		ZookeeperTimeout:          30 * time.Second,
+		ExporterMetadataAllowlist: []string{"Account"},
+		TargetLimit:      100,
+		EnableClustering: false,
+		Log:              zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.InfoLevel),
+	}
+)
+
+func getNotification() *pb.Notification {
+	return &pb.Notification{
+		Prefix: &pb.Path{Target: "test_target0", Origin: "b"},
+		Update: []*pb.Update{
+			{
+				Path: &pb.Path{
+					Elem: []*pb.PathElem{
+						{
+							Name: "path0",
+							Key: map[string]string{
+								"testKey": "testVal",
+							},
+						},
+						{
+							Name: "path1",
+						},
+					},
+				},
+				Val: &pb.TypedValue{Value: &pb.TypedValue_IntVal{IntVal: 1}},
+			},
+		},
+		Timestamp: time.Now().UTC().UnixNano(),
+	}
+}
+
+
+func main() {
+	server, err := statsd_server.NewServer(
+		serverAddress, serverPort, expNotifications, config.Log)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := server.Start(); err != nil {
+		panic(err)
+	}
+
+	e := statsd.NewStatsdExporter(config)	
+	err = e.Start(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	tstart := time.Now()
+	for i := 0; i < expNotifications; i+=1 {
+		e.Export(ctree.DetachedLeaf(getNotification()))
+		if i % 10000 == 0 {
+			config.Log.Info().Msgf("submitted notifications: %d", i + 1)
+		}
+	}
+	tend := time.Now()
+	config.Log.Info().Msgf("Submitted %d notifications in %s", expNotifications, tend.Sub(tstart))
+
+	done := make(chan struct{})
+	go func() {
+		// Wait for the server to receive all notifications
+		server.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		config.Log.Info().Msg("benchmark completed successfully")
+		tend = time.Now()
+		config.Log.Info().Msgf("total test duration: %s", tend.Sub(tstart))
+	case <-time.After(time.Duration(testTimeoutS) * time.Second):
+		config.Log.Info().Msg("statsd timeout while waiting for notifications")
+	}
+
+	server.PrintStats()
+}

--- a/gateway/benchmarks/statsd_server/cmd/main.go
+++ b/gateway/benchmarks/statsd_server/cmd/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/openconfig/gnmi-gateway/gateway/benchmarks/statsd_server"
+)
+
+var (
+	log = zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.InfoLevel)
+)
+
+type Config struct {
+	Address string
+	Port int
+	ExpNotifications int
+	StatsDumpIntervalS uint
+	ResetStatsOnDump bool
+}
+
+func parseArgs(cfg *Config) {
+	flag.StringVar(&cfg.Address, "address", "127.0.0.1", "The statsd server address")
+	flag.IntVar(&cfg.Port, "port", 8125, "The statsd server port")
+	flag.IntVar(
+		&cfg.ExpNotifications, "expNotifications", 0,
+		"The expected number of notifications, after which the server will close and " +
+		"dump the stats")
+	flag.UintVar(
+		&cfg.StatsDumpIntervalS, "statsDumpInterval", 0,
+		"Allows dumping the stats periodically, specified in seconds")
+	flag.BoolVar(
+		&cfg.ResetStatsOnDump, "resetStatsOnDump", false,
+		"If enabled, the stats will be reset after being printed")
+
+	flag.Parse()
+}
+
+func main() {
+	cfg := &Config{}
+	parseArgs(cfg)
+
+	server, err := statsd_server.NewServer(
+		cfg.Address, cfg.Port, cfg.ExpNotifications, log)
+	if err != nil {
+		panic(err)
+	}
+
+	stopSignal := make(chan os.Signal, 1)
+	signal.Notify(stopSignal, os.Interrupt)
+
+	go func() {
+		<- stopSignal
+		log.Info().Msg("received stop signal, cleaning up")
+		server.Stop()
+	}()
+
+	if cfg.StatsDumpIntervalS > 0 {
+		go func() {
+			for {
+				time.Sleep(time.Duration(cfg.StatsDumpIntervalS) * time.Second)
+				server.PrintStats()
+
+				if cfg.ResetStatsOnDump {
+					server.ResetStats()
+				}
+			}
+		}()
+	}
+
+	if err := server.Start(); err != nil {
+		panic(err)
+	}
+
+	server.Wait()
+	server.PrintStats()
+}

--- a/gateway/benchmarks/statsd_server/server.go
+++ b/gateway/benchmarks/statsd_server/server.go
@@ -1,0 +1,353 @@
+package statsd_server
+
+import (
+	"fmt"
+	"bytes"
+	"errors"
+	"io"
+	"math"
+	"net"
+	"regexp"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+
+var (
+	timestampRe, _ = regexp.Compile("Timestamp.?.?: ?([0-9]+)")
+)
+
+const (
+	tcpListenBufferSize = 1024 * 1024
+)
+
+// A simple statsd server used for benchmark purposes
+type StatsdSever struct {
+	address string
+	port int
+	// If set, the server will stop after receiving the specified
+	// amount of notifications.
+	expNotifications int
+
+	done chan struct{}
+	stopMutex sync.Mutex
+	stopped bool
+
+	wg sync.WaitGroup
+
+	latencyMutex sync.RWMutex
+	notifLatencyMs []uint32
+
+	receivedTcpNotif uint64
+	receivedUdpNotif uint64
+
+	log zerolog.Logger
+
+	udpListener *net.UDPConn
+	tcpListener net.Listener
+}
+
+func NewServer(
+	address string,
+	port int,
+	expNotifications int,
+	log zerolog.Logger,
+) (*StatsdSever, error) {
+	server := &StatsdSever{
+		address: address,
+		port: port,
+		expNotifications: expNotifications,
+		notifLatencyMs: make([]uint32, 0, expNotifications),
+		log: log,
+		done: make(chan struct{}),
+	}
+
+	return server, nil
+}
+
+func (s *StatsdSever) Start() error {
+	s.log.Info().Msg("starting server")
+	go s.listenUDP()
+	go s.listenTCP()
+
+	// TODO: consider waiting for an event
+	time.Sleep(1 * time.Second)
+
+	s.log.Info().Msg("started server")
+	return nil
+}
+
+func (s *StatsdSever) Stop() {
+	s.log.Info().Msg("stopping server")
+
+	s.stopMutex.Lock()
+	defer s.stopMutex.Unlock()
+
+	if !s.stopped {
+		close(s.done)
+
+		if s.tcpListener != nil {
+			s.tcpListener.Close()
+		}
+
+		if s.udpListener != nil {
+			s.udpListener.Close()
+		}
+
+		s.stopped = true
+	}
+
+	s.log.Info().Msg("stopped server")
+}
+
+func (s *StatsdSever) Wait() {
+	s.wg.Wait()
+}
+
+func (s *StatsdSever) appendLatency(val uint32) {
+	s.latencyMutex.Lock()
+	defer s.latencyMutex.Unlock()
+
+	s.notifLatencyMs = append(s.notifLatencyMs, val)
+}
+
+func (s *StatsdSever) ResetStats() {
+	defer s.latencyMutex.Unlock()
+	s.latencyMutex.Lock()
+
+	s.notifLatencyMs = make([]uint32, 0, s.expNotifications)
+	s.receivedTcpNotif = 0
+	s.receivedUdpNotif = 0
+}
+
+func (s *StatsdSever) PrintStats() {
+	defer s.latencyMutex.RUnlock()
+	s.latencyMutex.RLock()
+
+	sortedLatency := s.notifLatencyMs
+	sort.Slice(sortedLatency, func(i, j int) bool { return sortedLatency[i] < sortedLatency[j] })
+
+	var mean float64
+	var median uint32
+	var min90 uint32
+	var max90 uint32
+	var stdDev float64
+	var variance float64
+	var min uint32
+	var max uint32
+
+	var sum uint64
+	for _, val := range sortedLatency {
+		sum += uint64(val)
+	}
+	if len(sortedLatency) > 0 {
+		min = sortedLatency[0]
+		max = sortedLatency[len(sortedLatency) - 1]
+		mean = float64(sum / uint64(len(sortedLatency)))
+		median = sortedLatency[len(sortedLatency) / 2]
+		max90 = sortedLatency[int(0.9 * float32(len(sortedLatency)))]
+		min90 = sortedLatency[int(0.1 * float32(len(sortedLatency)))]
+
+		for _, val := range sortedLatency {
+			variance += math.Pow(float64(val) - mean, 2)
+		}
+
+		variance /= float64(len(sortedLatency))
+		stdDev = math.Sqrt(float64(variance))
+	}
+
+	fmt.Printf("\nReceived tcp notifications: %d\n", s.receivedTcpNotif)
+	fmt.Printf("Received udp notifications: %d\n", s.receivedUdpNotif)
+
+	fmt.Printf("\nLatency (ms) statistics\n")
+	fmt.Printf("min : %d\n", min)
+	fmt.Printf("max : %d\n", max)
+	fmt.Printf("sum : %d\n", sum)
+	fmt.Printf("median : %d\n", median)
+	fmt.Printf("mean : %f\n", mean)
+	fmt.Printf("variance : %f\n", variance)
+	fmt.Printf("stdDev : %f\n", stdDev)
+	fmt.Printf("count : %d\n", len(sortedLatency))
+	fmt.Printf("min 90 : %d\n", min90)
+	fmt.Printf("max 90 : %d\n", max90)
+}
+
+func (s *StatsdSever) listenUDP() error {
+	s.wg.Add(1)
+	defer s.wg.Done()
+
+	srv, err := net.ListenUDP(
+		"udp",
+		&net.UDPAddr{
+			IP: net.ParseIP(s.address),
+			Port: s.port,
+			Zone: "",
+		})
+	if err != nil {
+		s.log.Err(err).Msg("couldn't setup udp listener")
+		return err
+	}
+	defer srv.Close()
+	s.udpListener = srv
+
+	s.log.Info().Msg("started udp listener")
+
+	buf := make([]byte, 1024 * 64)
+	for {
+		select {
+		case <- s.done:
+			s.log.Info().Msg("shutting down udp listener")
+			return nil
+		default:
+			n, err := srv.Read(buf)
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) {
+					s.log.Info().Msg("udp listener closed")
+				} else {
+					s.log.Err(err).Msg("udp read error")
+				}
+				continue
+			}
+			if n == 0 {
+				s.log.Info().Msg("empty udp message")
+				continue
+			}
+			bufStr := string(buf[:n])
+			// Received single notification
+			if strings.Index(bufStr, "\n") == -1 {
+				s.handleNotification(bufStr, &s.receivedUdpNotif)
+			} else {
+				// Received a batch of notifications
+				for _, notif := range strings.Split(bufStr, "\n") {
+					s.handleNotification(notif, &s.receivedUdpNotif)
+				}
+			}
+			if s.expNotifications > 0 && s.receivedUdpNotif >= uint64(s.expNotifications) {
+				s.log.Info().Msg("received all notifications")
+				s.Stop()
+				return nil
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *StatsdSever) handleNotification(notif string, counter *uint64) {
+	if notif == "" {
+		return
+	}
+
+	atomic.AddUint64(counter, 1)
+
+	matches := timestampRe.FindStringSubmatch(notif)
+	if len(matches) >= 2 && matches[1] != "" {
+		timestampStr := matches[1]
+		timestampEpochNs, err := strconv.ParseInt(timestampStr, 10, 64)
+		if err == nil {
+		    timestamp := time.Unix(0, timestampEpochNs)
+			latency := time.Now().Sub(timestamp)
+			s.appendLatency(uint32(latency.Milliseconds()))
+		} else {
+			s.log.Err(err).Msgf("couldn't parse timestamp: %s, %s", timestampStr, err)
+		}
+	} else {
+		s.log.Info().Msgf("missing notification timestamp: %s %d", notif, len(notif))
+	}
+}
+
+func (s *StatsdSever) listenTCP() error {
+	s.wg.Add(1)
+	defer s.wg.Done()
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.address, s.port))
+	if err != nil {
+		s.log.Err(err).Msg("couldn't setup tcp listener")
+		return err
+	}
+	s.log.Info().Msg("started tcp listener")
+	defer ln.Close()
+	s.tcpListener = ln
+
+	for {
+		select {
+		case <- s.done:
+			s.log.Info().Msg("tcp listener shutting down")
+			return nil
+		default:
+			s.log.Info().Msg("waiting for tcp connections")
+			conn, err := ln.Accept()
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) {
+					s.log.Info().Msg("tcp connection closed")
+				} else {
+					s.log.Err(err).Msg("tcp connection failure")
+				}
+				continue
+			}
+
+			go func(c net.Conn) {
+				defer c.Close()
+
+				buf := bytes.NewBuffer(make([]byte, 0, tcpListenBufferSize))
+				for {
+					select {
+					case <- s.done:
+						s.log.Info().Msg("shutting down tcp listener")
+						return
+					default:
+						written, err := io.CopyN(buf, c, 1)
+						if err == io.EOF {
+							// connection closed
+							break
+						} else if err != nil {
+							s.log.Err(err).Msg("tcp read error")
+							break
+						}
+						if written == 0 {
+							continue
+						}
+
+						if bytes.Index(buf.Bytes(), []byte("\n")) != - 1 {
+							notif, err := buf.ReadString('\n')
+							if notif != "" {
+								s.handleNotification(notif, &s.receivedTcpNotif)
+								if s.expNotifications > 0 && s.receivedTcpNotif >= uint64(s.expNotifications) {
+									s.log.Info().Msg("received all notifications")
+									s.Stop()
+									return
+								}
+							}
+							if err == io.EOF {
+								continue
+							}
+							if err != nil {
+								s.log.Err(err).Msg("couldn't parse notification")
+								break
+							}
+						}
+
+						if buf.Len() > int(tcpListenBufferSize) {
+							newBuf := bytes.NewBuffer(make([]byte, 0, tcpListenBufferSize))
+							_, err := io.Copy(newBuf, buf)
+							if err != nil {
+								s.log.Err(err).Msg("couldn't rotate buffer")
+								break
+							}
+							buf = newBuf
+							s.log.Info().Msg("rotated tcp receive buffer")
+						}
+					}
+				}
+			}(conn)
+		}
+	}
+
+	return nil
+}

--- a/gateway/benchmarks/statsd_server/server.go
+++ b/gateway/benchmarks/statsd_server/server.go
@@ -20,7 +20,7 @@ import (
 
 
 var (
-	timestampRe, _ = regexp.Compile("Timestamp.?.?: ?([0-9]+)")
+	timestampRe, _ = regexp.Compile("[tT]imestamp.?.?: ?\"?([0-9]+)")
 )
 
 const (

--- a/gateway/exporters/statsd/statsd.go
+++ b/gateway/exporters/statsd/statsd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"strconv"
 	"time"
 
 	"github.com/cactus/go-statsd-client/v5/statsd"
@@ -27,8 +28,6 @@ type Metric struct {
 	Measurement string            `json:"Metric"`
 	Namespace   string            `json:"Namespace"`
 	Dims        map[string]string `json:"Dims"`
-	// ns since epoch
-	Timestamp   int64			  `json:"Timestamp"`
 	Value       interface{}       `json:"-"`
 }
 
@@ -65,9 +64,7 @@ func (e *StatsdExporter) Export(leaf *ctree.Leaf) {
 			Fields: make(map[string]interface{}),
 		}
 
-		metric := Metric{
-			Timestamp: notification.Timestamp,
-		}
+		metric := Metric{}
 
 		timestamp := time.Unix(0, notification.Timestamp)
 		beforeLimit := (time.Now()).Add(-30 * time.Minute)
@@ -146,6 +143,9 @@ func (e *StatsdExporter) Export(leaf *ctree.Leaf) {
 		metric.Dims = point.Tags
 		metric.Account = metric.Dims["Account"]
 		delete(metric.Dims, "Account")
+		// ns since epoch
+		metric.Dims["timestamp"] = strconv.FormatInt(notification.Timestamp, 10)
+
 
 		metricJSON, err := json.Marshal(metric)
 

--- a/gateway/exporters/statsd/statsd.go
+++ b/gateway/exporters/statsd/statsd.go
@@ -184,7 +184,11 @@ func (e *StatsdExporter) Start(connMgr *connections.ConnectionManager) error {
 	e.connMgr = connMgr
 
 	var err error
-	e.client, err = statsd.NewClient(e.config.Exporters.StatsdHost, "")
+	e.client, err = statsd.NewBufferedClient(
+		e.config.Exporters.StatsdHost, "",
+		time.Duration(300) * time.Millisecond, // flush interval
+		0, // flush size - default
+	)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
We're adding a simple benchmark that measures the notification latency and the amount of time required to push 150K notifications.

The statsd server may also be invoked separately, dumping the stats periodically or after being requested to stop through a SIGINT.

```
statsd-server -statsDumpInterval 10 -resetStatsOnDump true
```

While at it, we're switching to the buffered statsd udp client, which seems to provide a 60% perf improvement.
